### PR TITLE
PVC size to at least the DB_BACKEND_BYTES

### DIFF
--- a/charts/etcd-cluster-operator/Chart.yaml
+++ b/charts/etcd-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.3.3"
 description: Cloud Native etcd clusters
 name: etcd-cluster-operator
-version: 0.0.1
+version: 0.0.2
 keywords:
 - etcd
 - kv
@@ -20,3 +20,5 @@ maintainers:
   email: richard.kovacs@ondat.io
 - name: aeroniero33
   email: angelos.perivolaropoulos@ondat.io
+- name: arau
+  email: ferran@ondat.io

--- a/charts/etcd-cluster-operator/values.yaml
+++ b/charts/etcd-cluster-operator/values.yaml
@@ -21,7 +21,7 @@ cluster:
   # NOTE: We CANNOT use storageos here as this is the egg to Ondat's chicken
   storageclass: standard
   # Amount of storage to allocate per etcd volume
-  storage: 8Gi
+  storage: 12Gi
   # Resource requests and limits for etcd pods
   resources:
     requests:

--- a/charts/etcd-cluster-operator/values.yaml
+++ b/charts/etcd-cluster-operator/values.yaml
@@ -21,7 +21,7 @@ cluster:
   # NOTE: We CANNOT use storageos here as this is the egg to Ondat's chicken
   storageclass: standard
   # Amount of storage to allocate per etcd volume
-  storage: 1Gi
+  storage: 8Gi
   # Resource requests and limits for etcd pods
   resources:
     requests:

--- a/charts/ondat-operator/Chart.yaml
+++ b/charts/ondat-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.7.0"
 description: Cloud Native storage for containers
 name: ondat-operator
-version: 0.5.8
+version: 0.5.9
 keywords:
 - storage
 - block-storage


### PR DESCRIPTION
The DB_BACKEND_SIZE in the CR marks how big the database can grow even when partitioned, that usually translates into the size of the db in disk. In addition, we put 4 more GiB for the PVC than the 8GiB set by default so the WAL and other meta files have enough space. 