### PR TITLE
changed etcd operator storageclass from standard to default

### DIFF
--- a/charts/etcd-cluster-operator/values.yaml
+++ b/charts/etcd-cluster-operator/values.yaml
@@ -19,7 +19,7 @@ cluster:
   tls: true
   # Storageclass for etcd backing storage
   # NOTE: We CANNOT use storageos here as this is the egg to Ondat's chicken
-  storageclass: standard
+  storageclass: default
   # Amount of storage to allocate per etcd volume
   storage: 12Gi
   # Resource requests and limits for etcd pods

--- a/charts/ondat/values.yaml
+++ b/charts/ondat/values.yaml
@@ -72,7 +72,7 @@ etcd-cluster-operator:
     replicas: 5
     # Storageclass for etcd backing storage
     # NOTE: We CANNOT use storageos here as this is the egg to Ondat's chicken
-    storageclass: standard
+    storageclass: default
     # Amount of storage to allocate per etcd volume
     storage: 12Gi
     # Resource requests and limits for etcd pods


### PR DESCRIPTION
- as discussed last week, I have changed the etcd operator storage class in the `values.yaml` configuration files from `standard` to `default`