### PR TITLE
Fix releaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,10 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Add Ondat repository
-        run: helm dependency update charts/umbrella-charts/ondat
+      - name: Update Repository
+        run: |
+          helm repo update
+          helm dependency update charts/umbrella-charts/ondat
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0


### PR DESCRIPTION
previously was getting:

Error: can't get a valid version for repositories ondat-operator. Try
changing the version constraint in Chart.yaml

when releasing component chart + umbrella at once