### PR TITLE
fix: imagePullSecrets field missing

### DIFF
--- a/charts/component-charts/etcd-cluster-operator/templates/Deployment-storageos-etcd-controller-manager.yml
+++ b/charts/component-charts/etcd-cluster-operator/templates/Deployment-storageos-etcd-controller-manager.yml
@@ -25,6 +25,10 @@ spec:
                 matchLabels:
                   control-plane: etcd-controller-manager
               topologyKey: kubernetes.io/hostname
+      {{- with .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --enable-leader-election

--- a/charts/component-charts/etcd-cluster-operator/templates/Deployment-storageos-etcd-proxy.yml
+++ b/charts/component-charts/etcd-cluster-operator/templates/Deployment-storageos-etcd-proxy.yml
@@ -16,6 +16,10 @@ spec:
       labels:
         control-plane: proxy
     spec:
+      {{- with .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --api-port=8080

--- a/charts/component-charts/etcd-cluster-operator/templates/etcdcluster_cr.yaml
+++ b/charts/component-charts/etcd-cluster-operator/templates/etcdcluster_cr.yaml
@@ -20,10 +20,6 @@ spec:
   podTemplate:
     resources:
 {{ toYaml .Values.cluster.resources | indent 6 }}
-    {{- with .Values.images.imagePullSecrets }}
-    imagePullSecrets:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
     etcdEnv:
       - name: "ETCD_HEARTBEAT_INTERVAL"
         value: "500"

--- a/charts/component-charts/etcd-cluster-operator/templates/etcdcluster_cr.yaml
+++ b/charts/component-charts/etcd-cluster-operator/templates/etcdcluster_cr.yaml
@@ -20,6 +20,10 @@ spec:
   podTemplate:
     resources:
 {{ toYaml .Values.cluster.resources | indent 6 }}
+    {{- with .Values.images.imagePullSecrets }}
+    imagePullSecrets:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     etcdEnv:
       - name: "ETCD_HEARTBEAT_INTERVAL"
         value: "500"

--- a/charts/component-charts/etcd-cluster-operator/values.yaml
+++ b/charts/component-charts/etcd-cluster-operator/values.yaml
@@ -6,6 +6,8 @@ name: etcd-cluster-operator
 
 # Operator images
 images:
+  # imagePullSecrets:
+  #   - name: ""
   etcdClusterOperatorController:
     registry: docker.io/storageos
     image: etcd-cluster-operator-controller

--- a/charts/component-charts/ondat-operator/templates/cleanup.yaml
+++ b/charts/component-charts/ondat-operator/templates/cleanup.yaml
@@ -17,7 +17,10 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed, before-hook-creation"
     "helm.sh/hook-weight": "1"
-
+{{- with .Values.images.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -187,6 +190,10 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed, before-hook-creation"
     "helm.sh/hook-weight": "1"
+{{- with .Values.images.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 
 ---
 

--- a/charts/component-charts/ondat-operator/templates/operator.yaml
+++ b/charts/component-charts/ondat-operator/templates/operator.yaml
@@ -28,6 +28,10 @@ spec:
         control-plane: controller-manager
         release: {{ .Release.Name }}
     spec:
+      {{- with .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - --config=operator_config.yaml

--- a/charts/component-charts/ondat-operator/templates/service-account.yaml
+++ b/charts/component-charts/ondat-operator/templates/service-account.yaml
@@ -9,3 +9,7 @@ metadata:
     chart: {{ template "storageos.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.images.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/component-charts/ondat-operator/values.yaml
+++ b/charts/component-charts/ondat-operator/values.yaml
@@ -8,6 +8,8 @@ k8sDistro: default
 
 # operator-specific configuation parameters.
 images:
+  # imagePullSecrets:
+  #   - name: ""
   operator:
     registry: docker.io/storageos
     image: operator

--- a/charts/umbrella-charts/ondat/values.yaml
+++ b/charts/umbrella-charts/ondat/values.yaml
@@ -1,4 +1,8 @@
 ondat-operator:
+  images:
+    imagePullSecrets:
+      - name: "regsecret"
+
   # An exhaustive list of configurable options for ondat-operator
   # can be found at https://github.com/ondat/charts/blob/main/charts/ondat-operator/values.yaml
   cluster:
@@ -61,6 +65,10 @@ ondat-operator:
     storageClassName: storageos
 
 etcd-cluster-operator:
+  images:
+    imagePullSecrets:
+      - name: "regsecret"
+
   # An exhaustive list of configurable options for etcd-cluster-operator
   # can be found at https://github.com/ondat/charts/blob/main/charts/etcd-cluster-operator/values.yaml
   cluster:

--- a/charts/umbrella-charts/ondat/values.yaml
+++ b/charts/umbrella-charts/ondat/values.yaml
@@ -1,7 +1,8 @@
 ondat-operator:
-  images:
-    imagePullSecrets:
-      - name: "regsecret"
+  # Only for private registry usages
+  # images:
+  #   imagePullSecrets:
+  #     - name: "regsecret"
 
   # An exhaustive list of configurable options for ondat-operator
   # can be found at https://github.com/ondat/charts/blob/main/charts/ondat-operator/values.yaml
@@ -65,9 +66,10 @@ ondat-operator:
     storageClassName: storageos
 
 etcd-cluster-operator:
-  images:
-    imagePullSecrets:
-      - name: "regsecret"
+  # Only for private registry usages
+  # images:
+  #   imagePullSecrets:
+  #     - name: "regsecret"
 
   # An exhaustive list of configurable options for etcd-cluster-operator
   # can be found at https://github.com/ondat/charts/blob/main/charts/etcd-cluster-operator/values.yaml


### PR DESCRIPTION
## Context

On SNCF organization, clusters doesn't have internet. We worked with private registry an authentication.
The authentication required `imagePullSecret` field (SA or PodSpec).

## TODO 

/!\ This PR doesn't fix the problem on ETCD Operator. That required changes on CRD : https://github.com/storageos/etcd-cluster-operator/blob/main/api/v1alpha1/etcdcluster_types.go#L36

This case was seen with @chris-milsted on Slack 👍🏼 