### PR TITLE
update to use new etcd operator version and new etcd version

### DIFF
--- a/charts/component-charts/etcd-cluster-operator/Chart.yaml
+++ b/charts/component-charts/etcd-cluster-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v0.4.3"
+appVersion: "v0.4.4"
 description: Cloud Native etcd clusters
 name: etcd-cluster-operator
-version: 0.1.4
+version: 0.1.5
 keywords:
 - etcd
 - kv

--- a/charts/component-charts/etcd-cluster-operator/MAINTAINERS.md
+++ b/charts/component-charts/etcd-cluster-operator/MAINTAINERS.md
@@ -11,7 +11,7 @@ rm templates/*.yml
 Following that, we should obtain the new version and decompile it into the format expected by Helm:
 
 ```shell
-OPERATOR_VERSION=v0.4.3
+OPERATOR_VERSION=v0.4.4
 curl -Lo storageos-etcd-cluster-operator.yaml https://github.com/storageos/etcd-cluster-operator/releases/download/$OPERATOR_VERSION/storageos-etcd-cluster-operator.yaml
 curl -Lo storageos-etcd-cluster.yaml https://github.com/storageos/etcd-cluster-operator/releases/download/$OPERATOR_VERSION/storageos-etcd-cluster.yaml
 yq ea 'select(.kind=="CustomResourceDefinition")' storageos-etcd-cluster-operator.yaml --split-exp='"crds/" + (.metadata.name) + ".yml"'

--- a/charts/component-charts/etcd-cluster-operator/values.yaml
+++ b/charts/component-charts/etcd-cluster-operator/values.yaml
@@ -11,15 +11,15 @@ images:
   etcdClusterOperatorController:
     registry: docker.io/storageos
     image: etcd-cluster-operator-controller
-    tag: v0.4.3
+    tag: v0.4.4
   etcdClusterOperatorProxy:
     registry: docker.io/storageos
     image: etcd-cluster-operator-proxy
-    tag: v0.4.3
+    tag: v0.4.4
   etcd:
     registry: quay.io/coreos
     image: etcd
-    tag: v3.5.4
+    tag: v3.5.6
 
 cluster:
   # Whether to create the etcd cluster resource

--- a/charts/umbrella-charts/ondat/Chart.yaml
+++ b/charts/umbrella-charts/ondat/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: https://ondat.github.io/charts
   version: 0.7.3
 - name: etcd-cluster-operator
-  version: 0.1.5
+  version: 0.1.4
   repository: https://ondat.github.io/charts
 maintainers:
 - name: cvlc

--- a/charts/umbrella-charts/ondat/Chart.yaml
+++ b/charts/umbrella-charts/ondat/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: https://ondat.github.io/charts
   version: 0.7.3
 - name: etcd-cluster-operator
-  version: 0.1.4
+  version: 0.1.5
   repository: https://ondat.github.io/charts
 maintainers:
 - name: cvlc


### PR DESCRIPTION
Updates the etcd operator version, which updates the default etcd version (from v3.5.4 to v3.5.6). This mitigates the following data corruption issue:
https://groups.google.com/a/kubernetes.io/g/dev/c/sEVopPxKPDo 