### PR TITLE
fix default tag kube-scheduler (cluster version)

### DIFF
--- a/charts/component-charts/ondat-operator/templates/config-maps.yaml
+++ b/charts/component-charts/ondat-operator/templates/config-maps.yaml
@@ -52,7 +52,9 @@ data:
   RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR: "{{ .Values.images.csiV1NodeDriverRegistrar.registry}}/{{ .Values.images.csiV1NodeDriverRegistrar.image }}:{{ .Values.images.csiV1NodeDriverRegistrar.tag }}"
   {{- end }}
   {{- if .Values.images.kubeScheduler.image }}
-  RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag | default .Capabilities.KubeVersion.GitVersion }}"
+  # Regex to extract the version (semver) from the kube version.
+  # This avoid to have custom tag of distribution like "v1.18.0-eks-1-18-1".
+  RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag | default (regexFind "v([0-9]+)\.([0-9]+)\.([0-9]+)" .Capabilities.KubeVersion.GitVersion) }}"
   {{- end }}
   {{- if and .Values.images.metricsExporter.image .Values.images.metricsExporter.tag }}
   RELATED_IMAGE_METRICS_EXPORTER: "{{ .Values.images.metricsExporter.registry}}/{{ .Values.images.metricsExporter.image }}:{{ .Values.images.metricsExporter.tag }}"

--- a/charts/component-charts/ondat-operator/templates/config-maps.yaml
+++ b/charts/component-charts/ondat-operator/templates/config-maps.yaml
@@ -54,8 +54,6 @@ data:
   {{- if .Values.images.kubeScheduler.image }}
   RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag | default .Capabilities.KubeVersion.GitVersion }}"
   {{- end }}
-  {{- if and .Values.images.kubeScheduler.image .Values.images.kubeScheduler.tag }}
-  {{- end }}
   {{- if and .Values.images.metricsExporter.image .Values.images.metricsExporter.tag }}
   RELATED_IMAGE_METRICS_EXPORTER: "{{ .Values.images.metricsExporter.registry}}/{{ .Values.images.metricsExporter.image }}:{{ .Values.images.metricsExporter.tag }}"
   {{- end }}

--- a/charts/component-charts/ondat-operator/templates/config-maps.yaml
+++ b/charts/component-charts/ondat-operator/templates/config-maps.yaml
@@ -52,9 +52,7 @@ data:
   RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR: "{{ .Values.images.csiV1NodeDriverRegistrar.registry}}/{{ .Values.images.csiV1NodeDriverRegistrar.image }}:{{ .Values.images.csiV1NodeDriverRegistrar.tag }}"
   {{- end }}
   {{- if .Values.images.kubeScheduler.image }}
-  # Regex to extract the version (semver) from the kube version.
-  # This avoid to have custom tag of distribution like "v1.18.0-eks-1-18-1".
-  RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag | default (regexFind "v([0-9]+)\.([0-9]+)\.([0-9]+)" .Capabilities.KubeVersion.GitVersion) }}"
+  RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag | default (regexFind "v([0-9]+)\\.([0-9]+)\\.([0-9]+)" .Capabilities.KubeVersion.GitVersion) }}"
   {{- end }}
   {{- if and .Values.images.metricsExporter.image .Values.images.metricsExporter.tag }}
   RELATED_IMAGE_METRICS_EXPORTER: "{{ .Values.images.metricsExporter.registry}}/{{ .Values.images.metricsExporter.image }}:{{ .Values.images.metricsExporter.tag }}"

--- a/charts/component-charts/ondat-operator/templates/config-maps.yaml
+++ b/charts/component-charts/ondat-operator/templates/config-maps.yaml
@@ -51,8 +51,10 @@ data:
   {{- if and .Values.images.csiV1NodeDriverRegistrar.image .Values.images.csiV1NodeDriverRegistrar.tag }}
   RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR: "{{ .Values.images.csiV1NodeDriverRegistrar.registry}}/{{ .Values.images.csiV1NodeDriverRegistrar.image }}:{{ .Values.images.csiV1NodeDriverRegistrar.tag }}"
   {{- end }}
+  {{- if .Values.images.kubeScheduler.image }}
+  RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag | default .Capabilities.KubeVersion.GitVersion }}"
+  {{- end }}
   {{- if and .Values.images.kubeScheduler.image .Values.images.kubeScheduler.tag }}
-  RELATED_IMAGE_KUBE_SCHEDULER: "{{ .Values.images.kubeScheduler.registry}}/{{ .Values.images.kubeScheduler.image }}:{{ .Values.images.kubeScheduler.tag }}"
   {{- end }}
   {{- if and .Values.images.metricsExporter.image .Values.images.metricsExporter.tag }}
   RELATED_IMAGE_METRICS_EXPORTER: "{{ .Values.images.metricsExporter.registry}}/{{ .Values.images.metricsExporter.image }}:{{ .Values.images.metricsExporter.tag }}"


### PR DESCRIPTION
## Context

On SNCF organization, clusters doesn't have internet. We worked with private registry an authentication.
In this case, we need for each upgrade tag version (Kubernetes version) `kube-scheduler`.

This fix sets automatically the Kubernetes version for `kube-scheduler`.